### PR TITLE
Feature/improvements

### DIFF
--- a/dimmer.el
+++ b/dimmer.el
@@ -238,7 +238,8 @@ FRAC controls the dimming as defined in ‘dimmer-face-color’."
 (defun dimmer-process-all ()
   "Process all buffers and dim or un-dim each."
   (let ((selected (current-buffer))
-        (ignore (cl-some #'funcall dimmer-exclusion-predicates)))
+        (ignore (cl-some (lambda (f) (and (fboundp f) (funcall f)))
+                         dimmer-exclusion-predicates)))
     (setq dimmer-last-buffer selected)
     (unless ignore
       (dolist (buf (dimmer-filtered-buffer-list))

--- a/dimmer.el
+++ b/dimmer.el
@@ -123,18 +123,17 @@ wrong, then try HSV or RGB instead."
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;; implementation
+(defvar dimmer-last-buffer nil
+  "Identity of the last buffer to be made current.")
+
+(defvar dimmer-debug-messages nil
+  "Enable debugging output to *Messages* buffer.")
 
 (defvar-local dimmer-buffer-face-remaps nil
   "Per-buffer face remappings needed for later clean up.")
 
 (defconst dimmer-dimmed-faces (make-hash-table :test 'equal)
   "Cache of face names with their computed dimmed values.")
-
-(defconst dimmer-last-buffer nil
-  "Identity of the last buffer to be made current.")
-
-(defconst dimmer-debug-messages nil
-  "Enable debugging output to *Messages* buffer.")
 
 (defun dimmer-lerp (frac v0 v1)
   "Use FRAC to compute a linear interpolation of V0 and V1."

--- a/dimmer.el
+++ b/dimmer.el
@@ -82,9 +82,18 @@
   :group 'dimmer)
 (define-obsolete-variable-alias 'dimmer-percent 'dimmer-fraction)
 
-(defcustom dimmer-exclusion-regexp nil
-  "Regular expression describing buffer names that are never dimmed."
-  :type '(choice (const nil) (regexp))
+(defcustom dimmer-exclusion-regexp-list nil
+  "List of regular expressions describing buffer names that are never dimmed."
+  :type '(repeat (choice regexp))
+  :group 'dimmer)
+
+(defcustom dimmer-exclusion-predicates nil
+  "List of functions which prevent dimmer from altering dimmed buffer set.
+
+Functions in this list are called in turn with no arguments. If any function
+returns a non-nil value, no buffers will be added to or removed from the set of
+dimmed buffers."
+  :type '(repeat (choice function))
   :group 'dimmer)
 
 (defcustom dimmer-use-colorspace :cielab
@@ -219,8 +228,8 @@ FRAC controls the dimming as defined in ‘dimmer-face-color’."
      (lambda (win)
        (let* ((buf (window-buffer win))
               (name (buffer-name buf)))
-         (unless (and dimmer-exclusion-regexp
-                      (string-match-p dimmer-exclusion-regexp name))
+         (unless (cl-some (lambda (rxp) (string-match-p rxp name))
+                          dimmer-exclusion-regexp-list)
            (push buf buffers))))
      nil
      t)
@@ -228,12 +237,14 @@ FRAC controls the dimming as defined in ‘dimmer-face-color’."
 
 (defun dimmer-process-all ()
   "Process all buffers and dim or un-dim each."
-  (let ((selected (current-buffer)))
+  (let ((selected (current-buffer))
+        (ignore (cl-some #'funcall dimmer-exclusion-predicates)))
     (setq dimmer-last-buffer selected)
-    (dolist (buf (dimmer-filtered-buffer-list))
-      (if (eq buf selected)
-          (dimmer-restore-buffer buf)
-        (dimmer-dim-buffer buf dimmer-fraction)))))
+    (unless ignore
+      (dolist (buf (dimmer-filtered-buffer-list))
+        (if (eq buf selected)
+            (dimmer-restore-buffer buf)
+          (dimmer-dim-buffer buf dimmer-fraction))))))
 
 (defun dimmer-dim-all ()
   "Dim all buffers."


### PR DESCRIPTION
Two sets of changes to take a look at - the first extends the ways in which dimmer can be configured by the user, and should allow for better minibuffer support, and helm support, closing issues #10 and #15.

The second makes dimmer mostly asynchronous, which helped catch lots of instances where the selected buffer wasn't updating until the post-command-hook fired. Feel free to play with both, but they go a long way to improving how dimmer behaves on my system in most cases. 