### PR TITLE
Exclude buffers from dimming based on buffer-predicates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ refer to the issue number that was resolved.
 - Features
   - Added the ability to change the background color, the foreground
     color (default), or both [#20]
+  - Added `dimmer-buffer-exclusion-predicates` as another mechanism
+    to specify buffers that can't be dimmed, resolving [#25]
+  - Renamed `dimmer-exclusion-regexp-list` to `dimmer-buffer-exclusion-regexps`
+    to clarify what this setting does
 - Bugfixes
   - Fixed the dimming math when working in HSL colorspace [#21]
 

--- a/README.md
+++ b/README.md
@@ -57,11 +57,15 @@ adjusted when dimming.  Choices are `:foreground` (default),
 Range is 0.0 - 1.0, and default is 0.20.  Increase value if you
 like the other buffers to be more dim.
 
-* `dimmer-exclusion-regexp-list` can be used to specify buffers that
-should never be dimmed.  If the buffer name matches any regexp in this
-list then `dimmer.el` will not dim that buffer.  Note, this variable
-replaces `dimmer-exclusion-regexp` which is obsolete starting with
-release 0.4.0 of this package.)
+* `dimmer-buffer-exclusion-regexps` can be used to specify buffers
+that should never be dimmed.  If the buffer name matches any regexp in
+this list then `dimmer.el` will not dim that buffer.  Note, this
+variable replaces `dimmer-exclusion-regexp` and
+`dimmer-exclusion-regexp-list`, which are now obsolete.
+
+* `dimmer-buffer-exclusion-predicates` can be used to specify buffers
+that should never be dimmed.  If any predicate function in this list
+returns true for the buffer then `dimmer.el` will not dim that buffer.
 
 * `dimmer-prevent-dimming-predicates` can be used to prevent dimmer from
 altering the dimmed buffer list.  This can be used to detect cases

--- a/dimmer.el
+++ b/dimmer.el
@@ -383,7 +383,7 @@ FRAC controls the dimming as defined in ‘dimmer-face-color’."
               (name (buffer-name buf)))
          (unless (or (cl-some (lambda (rxp) (string-match-p rxp name))
                               dimmer-buffer-exclusion-regexps)
-                     (cl-some (lambda (f) (not (funcall f buf)))
+                     (cl-some (lambda (f) (funcall f buf))
                               dimmer-buffer-exclusion-predicates))
            (push buf buffers))))
      nil

--- a/dimmer.el
+++ b/dimmer.el
@@ -122,13 +122,16 @@ Choices are :foreground (default), :background, or :both."
   :group 'dimmer)
 
 (make-obsolete-variable
- 'dimmer-exclusion-regexp
- "`dimmer-exclusion-regexp` is obsolete and has no effect in this session.
-The variable has been superceded by `dimmer-exclusion-regexp-list`.
+  'dimmer-exclusion-regexp
+  "`dimmer-exclusion-regexp` is obsolete and has no effect in this session.
+The variable has been superseded by `dimmer-buffer-exclusion-regexps`.
 See documentation for details."
- "v0.4.0")
-(defcustom dimmer-exclusion-regexp-list '("^ \\*Minibuf-[0-9]+\\*$"
-                                          "^ \\*Echo.*\\*$")
+  "v0.4.0")
+
+(define-obsolete-variable-alias
+  'dimmer-exclusion-regexp-list 'dimmer-buffer-exclusion-regexps)
+(defcustom dimmer-buffer-exclusion-regexps '("^ \\*Minibuf-[0-9]+\\*$"
+                                              "^ \\*Echo.*\\*$")
   "List of regular expressions describing buffer names that are never dimmed."
   :type '(repeat (choice regexp))
   :group 'dimmer)
@@ -362,14 +365,16 @@ FRAC controls the dimming as defined in ‘dimmer-face-color’."
   "Get filtered subset of all visible buffers in all frames."
   (let (buffers)
     (walk-windows
-     (lambda (win)
-       (let* ((buf (window-buffer win))
-              (name (buffer-name buf)))
-         (unless (cl-some (lambda (rxp) (string-match-p rxp name))
-                          dimmer-exclusion-regexp-list)
-           (push buf buffers))))
-     nil
-     t)
+      (lambda (win)
+        (let* ((buf (window-buffer win))
+                (name (buffer-name buf)))
+          (unless (or (cl-some (lambda (rxp) (string-match-p rxp name))
+                        dimmer-buffer-exclusion-regexps)
+                    (cl-some (lambda (f) (not (funcall f buf)))
+                      dimmer-buffer-exclusion-predicates))
+            (push buf buffers))))
+      nil
+      t)
     buffers))
 
 (defun dimmer-process-all ()


### PR DESCRIPTION
Also, renamed `dimmer-exclusion-regexp-list` to `dimmer-buffer-exclusion-regexps` for consistancy