### PR TITLE
Fix hydra buffer detection

### DIFF
--- a/dimmer.el
+++ b/dimmer.el
@@ -206,7 +206,7 @@ wrong, then try HSL or RGB instead."
   "Convenience settings for hydra users."
   (with-no-warnings
     (add-to-list
-     'dimmer-exclusion-regexp-list "^\\*LV\\*$")))
+     'dimmer-exclusion-regexp-list "^ \\*LV\\*$")))
 
 (defun dimmer-configure-which-key ()
   "Convenience settings for which-key-users."


### PR DESCRIPTION
It has space at the beginning https://github.com/abo-abo/hydra/blob/e3beffdd804b87b20c87d7fb8e37d6eee2b0d763/lv.el#L81

I also added it `dimmer-prevent-dimming-predicates` because this buffer pops up automatically and dims main buffer.