### PR TITLE
specify group instead of requirement for minor mode definition

### DIFF
--- a/dimmer.el
+++ b/dimmer.el
@@ -584,7 +584,7 @@ when `dimmer-watch-frame-focus-events` is nil."
   nil
   :lighter ""
   :global t
-  :require 'dimmer
+  :group 'dimmer
   (if dimmer-mode
       (progn
         (dimmer-manage-frame-focus-hooks t)


### PR DESCRIPTION
It seems the idea of using :require tag is not to require itself. When requiring itself, as before this modification, by changing `dimmer-mode` through Easy Customization Interface, it creates the line

```
 '(dimmer-mode t nil (dimmer))
```

for `custom-set-variables`.  It causes error [1] when `dimmer` is still not installed (when it will be installed later on, e.g., through `package-install-selected-packages`).

By avoiding `dimmer` to require itself, the following line is inserted along with `custom-set-variables` through Easy Customization Interface:

```
 '(dimmer-mode t)
```

which allows the initialization process just fine even when `dimmer` is not installed yet.

[1] Error:

```
Debugger entered--Lisp error: (file-missing "Cannot open load file" "No such file or directory" "dimmer")
  require(dimmer)
  mapc(require (dimmer))
  custom-theme-set-variables(user ...)
  apply(custom-theme-set-variables user (...))
  custom-set-variables(...)
  ...
```