### PR TITLE
[fix #53] gracefully handle invalid faces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ refer to the issue number you resolved.
   - Add frog-menu buffer regexps to `dimmer-configure-posframe`
 - Bugfixes
   - Handle `reset` face-attribute gracefully, resolving [#68, #69]
+  - Handle faces that error on attribute lookup (e.g. `child-frame-border`), resolving [#53]
 - Development and CI improvements
   - Move to GitHub Actions CI
   - Adopt Eask instead of bespoke dev toolchain

--- a/dimmer.el
+++ b/dimmer.el
@@ -434,10 +434,20 @@ suitable for use with `face-remap-add-relative`."
 
 (defun dimmer-filtered-face-list ()
   "Return a filtered version of `face-list`.
-Filtering is needed to exclude faces that shouldn't be dimmed."
-  ;; `fringe` is problematic because it is shared for all windows,
-  ;; so for now we just leave it alone.
-  (remove 'fringe (face-list)))
+Excludes specific faces that should not be touched, plus faces that error
+on attribute lookup."
+  (let ((ok-p (lambda (f)
+                (and (not (eq f 'fringe))
+                     (condition-case nil
+                         (prog1 t (face-foreground f))
+                       (error nil)))))
+        result)
+    (dolist (f (face-list))
+      (if (funcall ok-p f)
+          (push f result)
+        (dimmer--dbg 2
+                     "dimmer-filtered-face-list: excluding %s" f)))
+    result))
 
 (defun dimmer-dim-buffer (buf frac)
   "Dim all the faces defined in the buffer BUF.


### PR DESCRIPTION
The root cause was that `dimmer` iterates all faces returned by (face-list) without verifying they actually exist on the current Emacs version.  If a package pre-emptively sets a face for a newer Emacs version but an older version of Emacs is running, then we fail trying to look up the face color.

Fixed by catching the error and omitting the undefined face from further handling.